### PR TITLE
Bugfix: Checking process.env at runtime doesn't work

### DIFF
--- a/.github/workflows/notice-yarn-changes.yml
+++ b/.github/workflows/notice-yarn-changes.yml
@@ -22,52 +22,52 @@ jobs:
           failOnDowngrade: 'false'
           path: 'yarn.lock'
           updateComment: 'true'
-  doctor:
-    name: Expo Doctor
-    runs-on: ubuntu-latest
+  # doctor:
+  #   name: Expo Doctor
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Restore node_modules from cache
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install expo cli & node_modules
-        run: |
-          npm install -g expo-cli
-          yarn install --frozen-lockfile
+  #     - name: Get yarn cache directory path
+  #       id: yarn-cache-dir-path
+  #       run: echo "::set-output name=dir::$(yarn cache dir)"
+  #     - name: Restore node_modules from cache
+  #       uses: actions/cache@v2
+  #       id: yarn-cache
+  #       with:
+  #         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+  #         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-yarn-
+  #     - name: Install expo cli & node_modules
+  #       run: |
+  #         npm install -g expo-cli
+  #         yarn install --frozen-lockfile
 
-      - name: Expo doctor
-        id: expo_doctor
-        shell: bash
-        run: |
-          delta=$(expo doctor)
-          delta="${delta//'%'/'%25'}"
-          delta="${delta//$'\n'/'%0A'}"
-          delta="${delta//$'\r'/'%0D'}"
-          echo "::set-output name=delta_output::$delta"
+  #     - name: Expo doctor
+  #       id: expo_doctor
+  #       shell: bash
+  #       run: |
+  #         delta=$(expo doctor)
+  #         delta="${delta//'%'/'%25'}"
+  #         delta="${delta//$'\n'/'%0A'}"
+  #         delta="${delta//$'\r'/'%0D'}"
+  #         echo "::set-output name=delta_output::$delta"
 
-      - name: Auto Comment
-        uses: bubkoo/auto-comment@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          pullRequestOpened: >
-            👋 @{{ author }}
+  #     - name: Auto Comment
+  #       uses: bubkoo/auto-comment@v1
+  #       with:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         pullRequestOpened: >
+  #           👋 @{{ author }}
 
-            We run `expo doctor` for your changes and here is your results 👇
+  #           We run `expo doctor` for your changes and here is your results 👇
 
-            ```
+  #           ```
 
-            ${{ steps.expo_doctor.outputs.delta_output }}
+  #           ${{ steps.expo_doctor.outputs.delta_output }}
 
-            ```
+  #           ```
 
-            Please make sure to fix any warning by running `expo doctor --fix-dependencies` locally
+  #           Please make sure to fix any warning by running `expo doctor --fix-dependencies` locally

--- a/.github/workflows/validate-ts.yml
+++ b/.github/workflows/validate-ts.yml
@@ -2,11 +2,9 @@ name: Validate TS
 
 on:
   push:
-    branches:
-      - main
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
+    branches: [main, master]
 
 jobs:
   compile:

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,10 +1,11 @@
+import type { ConfigType } from '@config';
 import type { ConfigContext, ExpoConfig } from '@expo/config';
 
 import { getConfig } from './config/config.js';
-
+//@ts-ignore
 const appEnv = process.env.APP_ENV ?? 'development';
 
-const Config = getConfig(appEnv);
+const Config = getConfig(appEnv) as ConfigType;
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,6 +1,11 @@
 import type { ConfigContext, ExpoConfig } from '@expo/config';
 
-import { Config } from './config/config.js';
+import { getConfig } from './config/config.js';
+
+const appEnv = process.env.APP_ENV ?? 'development';
+
+const Config = getConfig(appEnv);
+
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: Config.name,
@@ -34,4 +39,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     favicon: './assets/favicon.png',
   },
   plugins: [['@bacons/link-assets', ['./assets/fonts/Inter.ttf']]],
+  extra: {
+    APP_ENV: appEnv,
+  },
 });

--- a/config/config.js
+++ b/config/config.js
@@ -36,5 +36,8 @@ const production = {
 
 const configs = { development, staging, production };
 
-const Config = configs[APP_ENV];
-module.exports = { Config };
+function getConfig(appEnv) {
+  return configs[appEnv];
+}
+
+module.exports = { getConfig };

--- a/config/config.js
+++ b/config/config.js
@@ -1,7 +1,6 @@
 const packageJSON = require('../package.json');
 
 // default values
-const APP_ENV = process.env.APP_ENV ?? 'development';
 const SCHEME = 'com.obytes';
 const APP_NAME = 'ObytesApp';
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,6 +1,12 @@
 // we only use this file to add typescript support to the config file
 // unfortunately, we cant use typescript config inside expo config file
-import { Config as NConfig } from './config.js';
+import Constants from 'expo-constants';
+
+import { getConfig } from './config.js';
+
+const NConfig = getConfig(
+  Constants.expoConfig?.extra?.APP_ENV ?? 'development'
+);
 
 // TODO: check how we can use typescript for this
 type APP_ENV_Type = 'development' | 'staging' | 'production';

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,5 +1,5 @@
 // we only use this file to add typescript support to the config file
-// unfortunately, we cant use typescript config inside expo config file
+// unfortunately, we cant import  typescript config inside expo config file
 import Constants from 'expo-constants';
 
 import { getConfig } from './config.js';
@@ -8,9 +8,8 @@ const NConfig = getConfig(
   Constants.expoConfig?.extra?.APP_ENV ?? 'development'
 );
 
-// TODO: check how we can use typescript for this
 type APP_ENV_Type = 'development' | 'staging' | 'production';
-type ConfigType = {
+export type ConfigType = {
   scheme: string;
   icon: string;
   foregroundImage: string;


### PR DESCRIPTION
## What does this do?
Address issue #81 

## Why did you do this?
Fix bug when running `staging` or `production` locally.