### PR TITLE
Update lint-staged.config.js

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,10 +1,16 @@
 module.exports = {
   '**/*.{js,jsx,ts,tsx}': (filenames) => [
-    `yarn eslint --fix ${filenames.join(' ')}`,
+    `npx eslint --fix ${filenames
+      .map((filename) => `"${filename}"`)
+      .join(' ')}`,
   ],
   '**/*.(md|json)': (filenames) =>
-    `yarn prettier --write ${filenames.join(' ')}`,
+    `npx prettier --write ${filenames
+      .map((filename) => `"${filename}"`)
+      .join(' ')}`,
   'src/translations/*.(json)': (filenames) => [
-    `yarn eslint --fix ${filenames.join(' ')}`,
+    `npx eslint --fix ${filenames
+      .map((filename) => `"${filename}"`)
+      .join(' ')}`,
   ],
 };


### PR DESCRIPTION


## What does this do?

Avoiding errors in paths with spaces when lint-staged

## Why did you do this?
I had this error and got the solution in the lint-staged github repo

Take a look here
https://github.com/okonet/lint-staged/issues/773#issuecomment-1260416318

## Who/what does this impact?

No

## How did you test this?

Tested it on my own project where I had this error