### PR TITLE
fix: peers dependencies installation error 

### DIFF
--- a/eas-pre-install
+++ b/eas-pre-install
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+  npm install -g pnpm@8.6.5
+  pnpm --version
+fi

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "lint:translations": "eslint ./src/translations/ --fix --ext .json  ",
     "test": "jest",
     "test:ci": "mkdir -p ./coverage && pnpm run test --coverage | tee ./coverage/coverage.txt",
-    "test:watch": "pnpm run test --watch"
+    "test:watch": "pnpm run test --watch",
+    "eas-build-pre-install": "./eas-pre-install"
   },
   "dependencies": {
     "@bacons/link-assets": "^1.1.0",


### PR DESCRIPTION
## What does this do?

fix peers dependencies installation  error due to an old version of pnpm in expo cloud build machine android 

## How did you test this?
CLI 
