### PR TITLE
feat: Expo 49 allow to remove --dev-client from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "private": true,
   "scripts": {
-    "start": "EXPO_NO_DOTENV=1 expo start --dev-client",
+    "start": "EXPO_NO_DOTENV=1 expo start",
     "prebuild": "EXPO_NO_DOTENV=1 pnpm expo prebuild",
     "android": "EXPO_NO_DOTENV=1 expo run:android",
     "ios": "EXPO_NO_DOTENV=1 expo run:ios",


### PR DESCRIPTION
Expo 49 allow to remove `--dev-client` from scripts

## What does this do?

![image](https://github.com/obytes/react-native-template-obytes/assets/7753600/15086cc6-f22e-4819-8291-f89872af301c)


_Describe what your changes **do**; did you add a $COOL_FEATURE? Write about it here._

## Why did you do this?

_**Why** did you make these changes? This is your opportunity to provide the rationale that drove the design of your solution._

## Who/what does this impact?

_Does your code affect something downstream? Are there side effects people should know about? Tag any developers that should be kept abreast of this change._

## How did you test this?

_How did you test your change? Document it here._
