### PR TITLE
docs: fix typo in post-merge details

### DIFF
--- a/docs/src/content/docs/getting-started/rules-and-conventions.mdx
+++ b/docs/src/content/docs/getting-started/rules-and-conventions.mdx
@@ -46,7 +46,7 @@ As the name suggest, this hook will run before each commit and it will make sure
 
 ### post-merge
 
-As the name suggest, this hook will run after each merge and it will check if there is any changed in yarn.lock and if there is any, it will run `pnpm install` to make sure the dependencies are up to date.
+As the name suggest, this hook will run after each merge and it will check if there is any changed in pnpm-lock.yaml and if there is any, it will run `pnpm install` to make sure the dependencies are up to date.
 
 <Code file=".husky/post-merge" language="bash" />
 


### PR DESCRIPTION
## What does this do?

fix typo in _post-merge_ details in _rules-and-conventions_ page 

change **yarn.lock** to **pnpm-lock.yaml** since the main package manger for this template is **pnpm** and not **yarn**.
