### PR TITLE
refactor: refactor modal component + useModal hook

### DIFF
--- a/src/screens/settings/language-item.tsx
+++ b/src/screens/settings/language-item.tsx
@@ -4,23 +4,19 @@ import { useSelectedLanguage } from '@/core';
 import { translate } from '@/core';
 import type { Language } from '@/core/i18n/resources';
 import type { Option } from '@/ui';
-import { Options, useModalRef } from '@/ui';
+import { Options, useModal } from '@/ui';
 
 import { Item } from './item';
 
 export const LanguageItem = () => {
   const { language, setLanguage } = useSelectedLanguage();
-  const optionsRef = useModalRef();
-  const open = React.useCallback(
-    () => optionsRef.current?.present(),
-    [optionsRef]
-  );
+  const modal = useModal();
   const onSelect = React.useCallback(
     (option: Option) => {
       setLanguage(option.value as Language);
-      optionsRef.current?.dismiss();
+      modal.dismiss();
     },
-    [setLanguage, optionsRef]
+    [setLanguage, modal]
   );
 
   const langs = React.useMemo(
@@ -41,10 +37,10 @@ export const LanguageItem = () => {
       <Item
         text="settings.language"
         value={selectedLanguage?.label}
-        onPress={open}
+        onPress={modal.present}
       />
       <Options
-        ref={optionsRef}
+        ref={modal.ref}
         options={langs}
         onSelect={onSelect}
         value={selectedLanguage?.value}

--- a/src/screens/settings/theme-item.tsx
+++ b/src/screens/settings/theme-item.tsx
@@ -3,23 +3,20 @@ import React from 'react';
 import type { ColorSchemeType } from '@/core';
 import { translate, useSelectedTheme } from '@/core';
 import type { Option } from '@/ui';
-import { Options, useModalRef } from '@/ui';
+import { Options, useModal } from '@/ui';
 
 import { Item } from './item';
 
 export const ThemeItem = () => {
   const { selectedTheme, setSelectedTheme } = useSelectedTheme();
-  const optionsRef = useModalRef();
-  const open = React.useCallback(
-    () => optionsRef.current?.present(),
-    [optionsRef]
-  );
+  const modal = useModal();
+
   const onSelect = React.useCallback(
     (option: Option) => {
       setSelectedTheme(option.value as ColorSchemeType);
-      optionsRef.current?.dismiss();
+      modal.dismiss();
     },
-    [setSelectedTheme, optionsRef]
+    [setSelectedTheme, modal]
   );
 
   const themes = React.useMemo(
@@ -38,9 +35,13 @@ export const ThemeItem = () => {
 
   return (
     <>
-      <Item text="settings.theme.title" value={theme?.label} onPress={open} />
+      <Item
+        text="settings.theme.title"
+        value={theme?.label}
+        onPress={modal.present}
+      />
       <Options
-        ref={optionsRef}
+        ref={modal.ref}
         options={themes}
         onSelect={onSelect}
         value={theme?.value}

--- a/src/ui/core/modal/dynamic-modal.tsx
+++ b/src/ui/core/modal/dynamic-modal.tsx
@@ -5,7 +5,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import * as React from 'react';
 
-import { Modal, useModalRef } from './modal';
+import { Modal, useModal } from './modal';
 import type { DynamicModalProps, ModalRef } from './types';
 
 export const DynamicModal = React.forwardRef(
@@ -13,7 +13,7 @@ export const DynamicModal = React.forwardRef(
     { snapPoints = ['CONTENT_HEIGHT'], children, ...props }: DynamicModalProps,
     ref: ModalRef
   ) => {
-    const bottomSheetRef = useModalRef();
+    const modal = useModal();
     const {
       animatedHandleHeight,
       animatedSnapPoints,
@@ -23,13 +23,13 @@ export const DynamicModal = React.forwardRef(
 
     React.useImperativeHandle(
       ref,
-      () => (bottomSheetRef.current as BottomSheetModal) || null
+      () => (modal.ref.current as BottomSheetModal) || null
     );
 
     return (
       <Modal
         {...props}
-        ref={bottomSheetRef}
+        ref={modal.ref}
         snapPoints={animatedSnapPoints}
         handleHeight={animatedHandleHeight}
         contentHeight={animatedContentHeight}

--- a/src/ui/core/modal/modal.tsx
+++ b/src/ui/core/modal/modal.tsx
@@ -7,9 +7,15 @@ import { renderBackdrop } from './modal-backdrop';
 import { ModalHeader } from './modal-header';
 import type { ModalProps, ModalRef } from './types';
 
-export const useModalRef = () => {
+export const useModal = () => {
   const ref = React.useRef<BottomSheetModal>(null);
-  return ref;
+  const present = React.useCallback((data?: any) => {
+    ref.current?.present(data);
+  }, []);
+  const dismiss = React.useCallback(() => {
+    ref.current?.dismiss();
+  }, []);
+  return { ref, present, dismiss };
 };
 
 export const Modal = React.forwardRef(
@@ -26,33 +32,29 @@ export const Modal = React.forwardRef(
       () => getDetachedProps(detached),
       [detached]
     );
-    const bottomSheetRef = useModalRef();
+    const modal = useModal();
     const snapPoints = React.useMemo(() => _snapPoints, [_snapPoints]);
-
-    const dismiss = React.useCallback(() => {
-      bottomSheetRef.current?.dismiss();
-    }, [bottomSheetRef]);
 
     React.useImperativeHandle(
       ref,
-      () => (bottomSheetRef.current as BottomSheetModal) || null
+      () => (modal.ref.current as BottomSheetModal) || null
     );
 
     const renderHandleComponent = React.useCallback(
       () => (
         <>
           <View className="mt-2 h-1 w-12 self-center rounded-lg bg-gray-400 dark:bg-gray-700" />
-          <ModalHeader title={title} dismiss={dismiss} />
+          <ModalHeader title={title} dismiss={modal.dismiss} />
         </>
       ),
-      [title, dismiss]
+      [title, modal.dismiss]
     );
 
     return (
       <BottomSheetModal
         {...props}
         {...detachedProps}
-        ref={bottomSheetRef}
+        ref={modal.ref}
         index={0}
         snapPoints={snapPoints}
         backdropComponent={props.backdropComponent || renderBackdrop}

--- a/src/ui/core/select/select.tsx
+++ b/src/ui/core/select/select.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import colors from '@/ui/theme/colors';
 
-import { useModalRef } from '../modal';
+import { useModal } from '../modal';
 import { Text } from '../text';
 import { TouchableOpacity } from '../touchable-opacity';
 import { View } from '../view';
@@ -31,23 +31,16 @@ export const Select = (props: SelectProps) => {
     disabled = false,
     onSelect,
   } = props;
-  const optionsRef = useModalRef();
-  const open = React.useCallback(
-    () => optionsRef.current?.present(),
-    [optionsRef]
-  );
-  const close = React.useCallback(
-    () => optionsRef.current?.dismiss(),
-    [optionsRef]
-  );
+  const modal = useModal();
+
   const { colorScheme } = useColorScheme();
   const isDark = colorScheme === 'dark';
   const onSelectOption = React.useCallback(
     (option: Option) => {
       onSelect?.(option.value);
-      close();
+      modal.dismiss();
     },
-    [close, onSelect]
+    [modal, onSelect]
   );
 
   const { borderColor, bgColor, valueColor, labelColor } = useColors(!!error);
@@ -68,7 +61,7 @@ export const Select = (props: SelectProps) => {
         <TouchableOpacity
           className={`mt-0 flex-row items-center justify-center border-[1px] py-3 px-2  ${borderColor} rounded-md ${bgColor} text-[16px]`}
           disabled={disabled}
-          onPress={open}
+          onPress={modal.present}
         >
           <View className="flex-1">
             <Text variant="md" className={valueColor}>
@@ -79,7 +72,7 @@ export const Select = (props: SelectProps) => {
         </TouchableOpacity>
         {error && <Text variant="error">{error}</Text>}
       </View>
-      <Options ref={optionsRef} options={options} onSelect={onSelectOption} />
+      <Options ref={modal.ref} options={options} onSelect={onSelectOption} />
     </>
   );
 };


### PR DESCRIPTION
## What does this do?

Refactor `useModal` hook to export modal ref , `present` and  `dismiss` functions  instead of only  modal `ref`. 

## Why did you do this?

Whenever we use `useModalRef`, we usually need to create functions for present and dismiss. Exporting them from the hook makes using the modal much easier.

## Who/what does this impact?

This update modifies the modal API. Therefore, if you are using the modal hook, you will need to refactor your code.


## How did you test this?

Locally 
