### PR TITLE
CLI: update utils.js to show to cd into project before running

### DIFF
--- a/cli/utils.js
+++ b/cli/utils.js
@@ -106,7 +106,7 @@ const showMoreDetails = () => {
     '\n\n\n',
     chalk('🔥 Your project is ready to go! \n\n'),
     chalk('📱 Run your project: \n\n'),
-    chalk(`cd ${projectName}`),
+    chalk(`   cd ${projectName}`),
     chalk('   IOS     :  pnpm ios \n'),
     chalk('   Android :  pnpm android \n\n'),
     chalk.bold('📚 Starter Documentation: https://starter.obytes.com \n')

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -106,6 +106,7 @@ const showMoreDetails = () => {
     '\n\n\n',
     chalk('🔥 Your project is ready to go! \n\n'),
     chalk('📱 Run your project: \n\n'),
+    chalk(`cd ${projectName}`),
     chalk('   IOS     :  pnpm ios \n'),
     chalk('   Android :  pnpm android \n\n'),
     chalk.bold('📚 Starter Documentation: https://starter.obytes.com \n')


### PR DESCRIPTION
## What does this do?

Shows a message after the '📱 Run your project:` sentence saying cd into project before running

## Why did you do this?

To make it clear to understand that before running, one need to cd into the project

## Who/what does this impact?

No impact, only changes the message shown on CLI

## How did you test this?

Don't know how to test it as I need to deploy the package on NPM? I'd appreciate if a maintainer showed me.
