### PR TITLE
fix: switch safeareaview from react-native to react-native-safe-area-…

### DIFF
--- a/src/ui/core/view.tsx
+++ b/src/ui/core/view.tsx
@@ -1,5 +1,6 @@
 import { styled } from 'nativewind';
-import { SafeAreaView as NSafeAreaView, View as RNView } from 'react-native';
+import { View as RNView } from 'react-native';
+import { SafeAreaView as NSafeAreaView } from 'react-native-safe-area-context';
 
 export const View = styled(RNView);
 export const SafeAreaView = styled(NSafeAreaView);


### PR DESCRIPTION
…context

## What does this do?

switch SafeAreaView import from react-native to react-native-safe-area-context

## Why did you do this?

to fix Android statue bar overlapping while using soft input 

## Who/what does this impact?

there are no side effect

## How did you test this?

locally
