### PR TITLE
Lock tailwindcss version to 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "np": "^7.7.0",
     "prettier": "^2.8.8",
     "react-test-renderer": "^18.2.0",
-    "tailwindcss": "^3.3.2",
+    "tailwindcss": "3.3.2",
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,7 @@ devDependencies:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
   tailwindcss:
-    specifier: ^3.3.2
+    specifier: 3.3.2
     version: 3.3.2(ts-node@10.9.2)
   ts-jest:
     specifier: ^29.1.1


### PR DESCRIPTION
## What does this do?

 - locks tailwindcss version to 3.3.2
 


