### PR TITLE
(fix) TextInput RTL issue when focus

### DIFF
--- a/src/ui/input.tsx
+++ b/src/ui/input.tsx
@@ -105,6 +105,7 @@ export const Input = React.forwardRef<TextInput, NInputProps>((props, ref) => {
         {...inputProps}
         style={StyleSheet.flatten([
           { writingDirection: I18nManager.isRTL ? 'rtl' : 'ltr' },
+          { textAlign: I18nManager.isRTL ? 'right' : 'left' },
           inputProps.style,
         ])}
       />


### PR DESCRIPTION
## What does this do?

I have added textAlign property to textInput so It works fine on RTL.

## Why did you do this?

Without textAlign, RTL not working perfectly on textInput.