### PR TITLE
fix typo in link for typescript for react developers

### DIFF
--- a/docs/src/content/docs/getting-started/rules-and-conventions.mdx
+++ b/docs/src/content/docs/getting-started/rules-and-conventions.mdx
@@ -14,7 +14,7 @@ In order to enforce a consistent code style and avoid common issues in the codeb
 
 This starter uses TypeScript to provide type safety and avoid common bugs in the codebase. The project configuration is based on Expo config with some updates to support absolute imports.
 
-If you are not familiar with Typescript, you can check this article to learn more about it : [Typescript for React Developers](https://elazizi.com/how-to-learn-type-script-for-react-developers)
+If you are not familiar with Typescript, you can check this article to learn more about it : [Typescript for React Developers](https://elazizi.com/posts/how-to-learn-typescript-for-react-developers/)
 
 You can find more information about it [here](https://docs.expo.io/guides/typescript/).
 


### PR DESCRIPTION
Fixes typo for the docs in Rules and Conventions for section Typescript (Typescript for react developers).
The current link leads to a 404