### PR TITLE
feat(docs): add docs for env vars with github secrets

### DIFF
--- a/docs/src/content/docs/ci-cd/app-releasing-process.mdx
+++ b/docs/src/content/docs/ci-cd/app-releasing-process.mdx
@@ -116,6 +116,31 @@ All github workflows are already ready to be used in the starter. You just need 
 
 - EXPO_TOKEN: Expo token to authenticate with EAS. You can get generate yours [here](https://expo.dev/settings/access-tokens)
 
+### Github action and env variables
+
+For simplicity, we assume that all your environment variables are already added to your env files and have been pushed to your repository.
+
+If you prefer not to push env files (recommended), you need to add all your environment variables to GitHub secrets. Then, use `create-envfile` action to create the env file on the fly before the prebuild script.
+
+```yaml
+## .github/workflows/eas-build-prod.yml
+
+- name: Create envfile
+  uses: SpicyPizza/create-envfile@v2.0
+  with:
+    envkey_DEBUG: false
+    envkey_SECRET_KEY: ${{ secrets.PRODUCTION_SECRET_KEY }}
+    file_name: .env.production
+
+- name: ⏱️ EAS Build
+  uses: ./.github/actions/eas-build
+  with:
+    APP_ENV: production
+    EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+```
+
+This action will create a new env file `.env.production` with the `DEBUG` and `SECRET_KEY` variables you added to the action. so make sure to include all your env variables to the action.
+
 ## Create new release
 
 For QA release, Go to your GitHub repo actions tab and run `new-app-version` workflow with the your desired release type.
@@ -129,3 +154,7 @@ After successful execution, a new tag will be pushed to master and then `new-git
 After that, `eas-build-qa` workflow will be triggered automatically and build the app using EAS and distribute it to the QA team.
 
 For production release, Go to your GitHub repo actions tab and run `eas-build-prod` workflow manually.
+
+```
+
+```

--- a/docs/src/content/docs/getting-started/environment-vars-config.mdx
+++ b/docs/src/content/docs/getting-started/environment-vars-config.mdx
@@ -69,6 +69,10 @@ const _buildTimeEnv = {
 NEW_ENV_VAR=my-new-var
 ```
 
+::: note
+if you are not pushing env files to your repo(recomended), please make sure to check the [App releasing process](/ci-cd/app-releasing-process/#github-action-and-env-variables) to see how to create the env file on the fly before the prebuild script in the github actions.
+:::
+
 4. Make sure to run `pnpm prebuild` to load the new values.
 
 ```bash


### PR DESCRIPTION
## What does this do?

Add documentation for environment variables when using GitHub Actions, in case you do not want to push environment files.

## Why did you do this?

more clarity 

## Who/what does this impact?

NA

## How did you test this?

NA
