### PR TITLE
fix(docs): expo commands

### DIFF
--- a/docs/src/content/docs/getting-started/environment-vars-config.mdx
+++ b/docs/src/content/docs/getting-started/environment-vars-config.mdx
@@ -104,7 +104,7 @@ As mentioned earlier, `zod` is used to validate environment variables at runtime
 ```bash
 ❌ Invalid environment variables: { TEST: [ 'Required' ] }
 ❌ Missing variables in .env.development file, Make sure all required variables are defined in the .env.development file.
-💡 Tip: If you recently updated the .env.development file and the error still persists, try restarting the server with the -cc flag to clear the cache.
+💡 Tip: If you recently updated the .env.development file and the error still persists, try restarting the server with the -c flag to clear the cache.
 ```
 
 :::note[Important]

--- a/docs/src/content/docs/guides/upgrading-deps.mdx
+++ b/docs/src/content/docs/guides/upgrading-deps.mdx
@@ -34,7 +34,7 @@ pnpm test ## tests
 pnpm prebuild --clean ## clean ios and android build folders and regenerate them
 pnpm ios ## run ios build
 pnpm android ## run android build
-pnpm start --clear ## start the server
+pnpm start -c ## start the server
 ```
 
 :::info
@@ -81,7 +81,7 @@ pnpm test ## tests
 pnpm prebuild --clean ## clean ios and android build folders and regenerate them
 pnpm ios ## run ios build
 pnpm android ## run android build
-pnpm start --clear ## start the server
+pnpm start -c ## start the server
 ```
 
 Unfortunately, there is no magic trick here in case you have any issues while running your checks, Fixing those errors may require some manual effort. You can start by reading the error message and identifying any relevant packages that may be causing the issue. Check the changelog of those packages to see if there have been any recent updates that might have introduced breaking changes. This will help you to pinpoint the root cause of the issue and take the necessary steps to resolve it.
@@ -147,7 +147,7 @@ pnpm test ## tests
 pnpm prebuild --clean ## clean ios and Android build folders and regenerate them
 pnpm ios ## run ios build
 pnpm android ## run android build
-pnpm start --clear ## start the server
+pnpm start -c ## start the server
 ```
 
 If you are lucky enough and everything works as expected without any issues, you can now update the rest of the dependencies.

--- a/docs/src/content/docs/guides/upgrading-deps.mdx
+++ b/docs/src/content/docs/guides/upgrading-deps.mdx
@@ -31,10 +31,10 @@ pnpm run doctor ## check for any issues with the dependencies you added to your 
 pnpm lint ## linting
 pnpm type-check ## type checking
 pnpm test ## tests
-pnpm prebuild -clean ## clean ios and android build folders and regenerate them
+pnpm prebuild --clean ## clean ios and android build folders and regenerate them
 pnpm ios ## run ios build
 pnpm android ## run android build
-pnpm start --cc ## start the server
+pnpm start --clear ## start the server
 ```
 
 :::info
@@ -78,10 +78,10 @@ pnpm install ## install new dependencies
 pnpm lint ## linting
 pnpm type-check ## type checking
 pnpm test ## tests
-pnpm prebuild -clean ## clean ios and android build folders and regenerate them
+pnpm prebuild --clean ## clean ios and android build folders and regenerate them
 pnpm ios ## run ios build
 pnpm android ## run android build
-pnpm start --cc ## start the server
+pnpm start --clear ## start the server
 ```
 
 Unfortunately, there is no magic trick here in case you have any issues while running your checks, Fixing those errors may require some manual effort. You can start by reading the error message and identifying any relevant packages that may be causing the issue. Check the changelog of those packages to see if there have been any recent updates that might have introduced breaking changes. This will help you to pinpoint the root cause of the issue and take the necessary steps to resolve it.
@@ -144,10 +144,10 @@ pnpm install ## install new dependencies
 pnpm lint ## linting
 pnpm type-check ## type checking
 pnpm test ## tests
-pnpm prebuild -clean ## clean ios and Android build folders and regenerate them
+pnpm prebuild --clean ## clean ios and Android build folders and regenerate them
 pnpm ios ## run ios build
 pnpm android ## run android build
-pnpm start --cc ## start the server
+pnpm start --clear ## start the server
 ```
 
 If you are lucky enough and everything works as expected without any issues, you can now update the rest of the dependencies.

--- a/docs/src/content/docs/guides/upgrading-deps.mdx
+++ b/docs/src/content/docs/guides/upgrading-deps.mdx
@@ -50,7 +50,7 @@ Visit the npm package registry [here](https://www.npmjs.com/package/expo) to ens
 Once you have confirmed that you have the latest version, open your terminal and enter the following command:
 
 ```bash
-pnpm add expo@lastVersion
+pnpm add expo@latest
 ## pnpm add expo@48.0.5 for example
 ```
 

--- a/env.js
+++ b/env.js
@@ -138,7 +138,7 @@ if (parsed.success === false) {
     parsed.error.flatten().fieldErrors,
 
     `\n❌ Missing variables in .env.${APP_ENV} file, Make sure all required variables are defined in the .env.${APP_ENV} file.`,
-    `\n💡 Tip: If you recently updated the .env.${APP_ENV} file and the error still persists, try restarting the server with the -cc flag to clear the cache.`
+    `\n💡 Tip: If you recently updated the .env.${APP_ENV} file and the error still persists, try restarting the server with the -c flag to clear the cache.`
   );
   throw new Error(
     'Invalid environment variables, Check terminal for more details '


### PR DESCRIPTION
## What does this do?

- [x] fixed docs clear cache commands
- [x] fixed docs install latest expo version command

## Why did you do this?

Incorrect commands leading to CLI errors.

## Who/what does this impact?

Everyone who reads the docs.

## How did you test this?

By running the commands.

## Result

**Before**

with `-clean` ❌

<img width="650" alt="Screenshot 2024-09-18 at 12 41 00" src="https://github.com/user-attachments/assets/efe76f7d-a840-4757-b636-d6e1e68f9382">


with `--cc` ❌

<img width="635" alt="Screenshot 2024-09-18 at 12 41 09" src="https://github.com/user-attachments/assets/3c1a52d3-b668-4e35-8c8b-f923d986d717">

with `expo@lastVersion` ❌

<img width="889" alt="Screenshot 2024-09-18 at 12 41 18" src="https://github.com/user-attachments/assets/43957865-d335-4ce7-8b62-78ee5568d815">

**After**

with `--clean` ✅

<img width="689" alt="Screenshot 2024-09-18 at 12 41 27" src="https://github.com/user-attachments/assets/f8375e5d-ab06-4624-8400-b318abacd1e5">


with `-c` ✅

<img width="640" alt="Screenshot 2024-09-18 at 12 43 35" src="https://github.com/user-attachments/assets/61726a40-d801-4d2a-9d43-602db0b067a0">

with `expo@latest` ✅

<img width="1083" alt="Screenshot 2024-09-18 at 12 44 06" src="https://github.com/user-attachments/assets/72207c16-137a-4dd3-b833-f75778aa74c8">
