### PR TITLE
Fix Check Mark Display in Select Component and Update Documentation

### DIFF
--- a/docs/src/content/docs/ui-and-theme/components.mdx
+++ b/docs/src/content/docs/ui-and-theme/components.mdx
@@ -249,19 +249,20 @@ Feel free to update the component implementation to fit your need and as you kee
 - `error`: `string` - Input error message
 - `options` : array of `{ label: string; value: string | number }` - List of items to select from
 - `value` : `string | number` - Selected item value
-- `onSelect`: `(option: Option) => void;` - Callback function to handle item selection
+- `onSelect`: `(option:  string | number ) => void`- Callback function to handle item selection
 - `placeholder`: `string`- Placeholder text
 - `disabled`: `boolean` - Disable select input (default: `false`)
+
 
 **Use Case**
 
 ```tsx
 import * as React from 'react';
 
-import type { Option } from '@/ui';
+import type { OptionType } from '@/ui'
 import { SelectInput, View } from '@/ui';
 
-const options: Option[] = [
+const options: OptionType[] = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'strawberry', label: 'Strawberry' },
   { value: 'vanilla', label: 'Vanilla' },
@@ -276,7 +277,7 @@ const MyComponent = () => {
         error="Select is required"
         options={options}
         value={value}
-        onSelect={(option) => setValue(option.value)}
+        onSelect={(option) => setValue(option)}
       />
     </View>
   );

--- a/src/ui/select.tsx
+++ b/src/ui/select.tsx
@@ -221,6 +221,7 @@ export const Select = (props: SelectProps) => {
         ref={modal.ref}
         options={options}
         onSelect={onSelectOption}
+        value={value}
       />
     </>
   );


### PR DESCRIPTION
- This pull request updates the `Select` component code to fix the check mark on the select options, as it was not displaying. This issue is resolved by passing the `value` prop to the `<Options>` component:

**Before:**
```tsx
<Options
  testID={testID}
  ref={modal.ref}
  options={options}
  onSelect={onSelectOption}
/>
```

**After:**
```tsx
<Options
  testID={testID}
  ref={modal.ref}
  options={options}
  onSelect={onSelectOption}
  value={value}
/>
```

- Additionally, this pull request updates the select usage example in the documentation to reflect the updated Option type. The import statement for the Option type has been changed to OptionType, and the options array has been modified to use this new type.

**Before:**
```tsx
import type { Option } from '@/ui';
......
const options: Option[] = [
  { value: 'chocolate', label: 'Chocolate' },
  { value: 'strawberry', label: 'Strawberry' },
  { value: 'vanilla', label: 'Vanilla' },
];
......
onSelect={(option) => setValue(option.value)}
......
```

**After:**
```tsx
import type { OptionType } from '@/ui'
......
const options: OptionType[] = [
  { value: 'chocolate', label: 'Chocolate' },
  { value: 'strawberry', label: 'Strawberry' },
  { value: 'vanilla', label: 'Vanilla' },
];
......
onSelect={(option) => setValue(option)}
......
```
