### PR TITLE
Fix:  ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "prebuild:developme…" and gradle plugin issue with java version

### DIFF
--- a/.github/actions/setup-jdk-generate-apk/action.yml
+++ b/.github/actions/setup-jdk-generate-apk/action.yml
@@ -30,7 +30,7 @@ runs:
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu' # See 'Supported distributions' for available options
-        java-version: '11'
+        java-version: '17'
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "preinstall": "npx only-allow pnpm",
     "start:staging": "cross-env APP_ENV=staging pnpm run start",
     "prebuild:staging": "cross-env APP_ENV=staging pnpm run prebuild",
+    "prebuild:development": "cross-env APP_ENV=development pnpm run prebuild",
     "android:staging": "cross-env APP_ENV=staging pnpm run android",
     "ios:staging": "cross-env APP_ENV=staging pnpm run ios",
     "start:production": "cross-env APP_ENV=production pnpm run start",


### PR DESCRIPTION
## What does this do?

It fixes this issue https://github.com/obytes/react-native-template-obytes/issues/370 and https://github.com/obytes/react-native-template-obytes/issues/372

## Why did you do this?

I have added ```prebuild:development``` script on package.json
and added ```java-version: '17'``` in here ```.github/actions/setup-jdk-generate-apk/action.yml```

## Who/what does this impact?

Other than solving the issue, It should not affect any other parts of this template.

## How did you test this?

I have tested with my project.