### PR TITLE
fix(docs): update command to install sentry

### DIFF
--- a/docs/src/content/docs/recipes/sentry-setup.mdx
+++ b/docs/src/content/docs/recipes/sentry-setup.mdx
@@ -87,7 +87,7 @@ The starter kit did not come with Sentry pre-configured, but it's very easy to s
 5. Now you can install the Sentry SDK in your project.
 
    ```bash
-   npm install @sentry/react-native
+   npx expo install @sentry/react-native
    ```
 
 6. Add Sentry plugin config to your `app.config.ts` file.


### PR DESCRIPTION
## What does this do?

Use the `expo install` command to ensure we are using the correct Sentry version recommended by Expo.

Fix #376 