### PR TITLE
feat: add dynamic params to text

### DIFF
--- a/src/ui/text.tsx
+++ b/src/ui/text.tsx
@@ -8,7 +8,7 @@ import { translate } from '@/core/i18n';
 
 interface Props extends TextProps {
   className?: string;
-  tx?: TxKeyPath | { key: TxKeyPath; params: { [key: string]: any } };
+  tx?: TxKeyPath | { key: TxKeyPath; options: { [key: string]: string } };
 }
 
 export const Text = ({
@@ -42,7 +42,7 @@ export const Text = ({
       {tx
         ? typeof tx === 'string'
           ? translate(tx)
-          : translate(tx.key, tx.params)
+          : translate(tx.key, tx.options)
         : children}
     </NNText>
   );

--- a/src/ui/text.tsx
+++ b/src/ui/text.tsx
@@ -8,7 +8,7 @@ import { translate } from '@/core/i18n';
 
 interface Props extends TextProps {
   className?: string;
-  tx?: TxKeyPath;
+  tx?: TxKeyPath | { key: TxKeyPath; params: { [key: string]: any } };
 }
 
 export const Text = ({
@@ -22,9 +22,9 @@ export const Text = ({
     () =>
       twMerge(
         'text-base text-black  dark:text-white  font-inter font-normal',
-        className
+        className,
       ),
-    [className]
+    [className],
   );
 
   const nStyle = React.useMemo(
@@ -35,11 +35,15 @@ export const Text = ({
         },
         style,
       ]) as TextStyle,
-    [style]
+    [style],
   );
   return (
     <NNText className={textStyle} style={nStyle} {...props}>
-      {tx ? translate(tx) : children}
+      {tx
+        ? typeof tx === 'string'
+          ? translate(tx)
+          : translate(tx.key, tx.params)
+        : children}
     </NNText>
   );
 };


### PR DESCRIPTION
## What does this do?

This PR extends the `Text` component to support translation parameters by modifying the `tx` prop to accept an object with a translation key and parameters. This allows developers to use dynamic, interpolated values within translations (e.g., inserting names or numbers into strings).

## Why did you do this?

This change was made to improve the flexibility of the `Text` component, particularly for internationalization. In many cases, translations require dynamic content (e.g., greetings with a user’s name), and this update allows developers to pass those parameters directly through the component. It simplifies the code needed for multi-language support and enhances readability.

## Who/what does this impact?

This change impacts developers using the `Text` component for localized content, as it enables dynamic translations without requiring custom workarounds. This is especially relevant for teams working on multilingual applications that need flexibility in handling text. It should not introduce any breaking changes to existing functionality, as it maintains backward compatibility with the previous `tx` prop type.

## How did you test this?

- Verified that the `Text` component correctly renders static translations as before.
- Tested the component with translations that include dynamic parameters, ensuring they render as expected.
- Checked the component in RTL and LTR layouts to confirm no side effects with the added parameter support.
