### PR TITLE
chore: fix husky deprecated warning

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
 


### PR DESCRIPTION
## What does this do?

After the `pnpm install`, got the following `warnings` while committing the changes.

<img width="739" alt="husky-warning" src="https://github.com/user-attachments/assets/263fa923-a66c-4467-8928-26507105222a">




## Why did you do this?

It seems that after the release of version 9.0.1 (https://github.com/typicode/husky/releases/tag/v9.0.1) indicate those two lines were deprecated and need to be removed.
  - see the `How to Migrate` section in the release notes.

## Who/what does this impact?

Does not have significant impact but definitely improve the DX.

## How did you test this?

You need to clone the project and 
   - `pnpm i`
   - make some changes in the codebase
   - commit the changes
   - warning will appear in the terminal as shown in the attachment

