### PR TITLE
Fix grammatical error and improve sentence structure

### DIFF
--- a/docs/src/content/docs/getting-started/create-new-app.md
+++ b/docs/src/content/docs/getting-started/create-new-app.md
@@ -36,7 +36,7 @@ npx create-obytes-app@latest MyApp
 The command will create an expo app named `MyApp` and install all the dependencies added by the starter.
 
 :::note
-Because we're using the Expo custom dev client to support native dependencies with the starter. The Expo Go app is not an option to consider here; instead, you need to create the app and install it on your simulator or device to start using it.
+Because we're using the Expo custom dev client to support native dependencies with the starter, The Expo Go app is not an option to consider here. Instead, you need to create the app and install it on your simulator or device to start using it.
 :::
 
 :::note


### PR DESCRIPTION
## What does this do?
This PR fixes a grammatical error in the documentation for creating a new app. There was an incomplete sentence that I have combined with the next sentence. I've also replaced the semicolon with a full stop for greater clarity.

## Why did you do this?
I wanted to improve the documentation quality.

## Who/what does this impact?
It concerns the [Create New App](https://starter.obytes.com/getting-started/create-new-app/) page.

## How did you test this?
N/A.
