### PR TITLE
fix: fix focuse aware statue bar crash in web

### DIFF
--- a/src/components/ui/focus-aware-status-bar.tsx
+++ b/src/components/ui/focus-aware-status-bar.tsx
@@ -1,12 +1,15 @@
 import { useIsFocused } from '@react-navigation/native';
 import { useColorScheme } from 'nativewind';
 import * as React from 'react';
+import { Platform } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 
 type Props = { hidden?: boolean };
 export const FocusAwareStatusBar = ({ hidden = false }: Props) => {
   const isFocused = useIsFocused();
   const { colorScheme } = useColorScheme();
+
+  if (Platform.OS === 'web') return null;
 
   return isFocused ? <SystemBars style={colorScheme} hidden={hidden} /> : null;
 };


### PR DESCRIPTION
# What does this do?
- Removes SystemBars rendering on web

# Why did you do this? 
- SystemBars is a native-only component and was causing runtime errors in browser

# Who/what does this impact?
- Fixes web application crashes
- No changes to native mobile functionality

# How did you test this?
- Verified web app loads without crashes
- Confirmed native StatusBar still works on iOS/Android
