### PR TITLE
fix(docs): fix typo in authentication guides docs

### DIFF
--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -34,7 +34,7 @@ The store is composed of 2 states and 3 actions:
 
   For the Demo app `useToken` is a simple object that contains the `accessToken` and the `refreshToken`. You can add more fields if you update the `TokenType` type in `src/lib/auth/utils.ts`.
 
-- `signIn`: TThe function performs user sign-in. It accepts a token as a parameter, sets the token state, stores it locally, and updates the status to `signIn`.
+- `signIn`: The function performs user sign-in. It accepts a token as a parameter, sets the token state, stores it locally, and updates the status to `signIn`.
 
 - `signOut`: The action to sign out the user. It sets the token state to `null` and removes it from the storage as well as setting the status to `signOut`.
 


### PR DESCRIPTION
## What does this do?

Fix a small typo in the guides for authentication section.

## Why did you do this?

I was reading the docs when I discovered this tiny issue so I decided to inform you about it. The second reason is the love of open source I like to be a part of it even for a small fix like this one.

## Who/what does this impact?

This will improve the readability of the docs and ultimately improve the starter which I absolutely like and use.

## How did you test this?

It's only a typo in text no need for test I guess 🤗
