### PR TITLE
typo(docs): Change sur to sure

### DIFF
--- a/docs/src/content/docs/guides/upgrading-deps.mdx
+++ b/docs/src/content/docs/guides/upgrading-deps.mdx
@@ -22,7 +22,7 @@ To update most of the dependencies that come with the starter, you can follow th
 
 First, go to GitHub and compare your `osMetadata.initVersion` in your `package.json` with the latest release. Check if the `package.json` has been updated. Then, copy the new dependencies and devDependencies versions and paste them into your package.json file.
 
-Finally, run the following commands to make sur everything is working as expected:
+Finally, run the following commands to make sure everything is working as expected:
 
 ```bash
 rm -rf node_modules ## remove node_modules folder


### PR DESCRIPTION
## What does this do?

Solves a typo error in docs.

## Why did you do this?

I was reading the docs and found this typo and thought to correct it as my contribution to this great repo.

## Who/what does this impact?

Documents->Guides->Upgrade Dependencies

## How did you test this?

By my eyes.
