### PR TITLE
Added permissions for lint & type check workflows

### DIFF
--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -18,6 +18,10 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+  pull-requests: write
+  
 jobs:
   lint:
     name: Lint TS (eslint, prettier)

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -18,6 +18,10 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   type-check:
     name: Type Check (tsc)


### PR DESCRIPTION
## What does this do?
- Added permissions for lint & type check workflows 

##Context : 
-   GitHub added some security checks. Every workflow that requires adding comments to a pull request (PR) or annotations—such as Reviewdog—needs this permission