### PR TITLE
fix: update SystemBars style based on the inverse of color scheme

### DIFF
--- a/src/components/ui/focus-aware-status-bar.tsx
+++ b/src/components/ui/focus-aware-status-bar.tsx
@@ -11,5 +11,9 @@ export const FocusAwareStatusBar = ({ hidden = false }: Props) => {
 
   if (Platform.OS === 'web') return null;
 
-  return isFocused ? <SystemBars style={colorScheme} hidden={hidden} /> : null;
+  return isFocused ? (
+    <SystemBars
+      style={colorScheme === 'light' ? 'dark' : 'light'}
+      hidden={hidden}
+    />
 };


### PR DESCRIPTION
## What does this do?

Fixes the focus aware status bar component with the theme based on the color scheme

## Why did you do this?

With the original template, i could never see the system bar even though it was not hidden because the style was the same as the colour scheme

e.g. style would be light when the theme was light and hence it would be white on white
and vice versa, then it would be black on black

Let me know if i am the one thats wrong and if i did something wrong

## Who/what does this impact?

No

## How did you test this?

Just locally by running pnpm run ios through the simular

Can add more tests if that iis required
