### PR TITLE
doc: instruction not to use 'obytes' in project name

### DIFF
--- a/docs/src/content/docs/getting-started/create-new-app.md
+++ b/docs/src/content/docs/getting-started/create-new-app.md
@@ -47,6 +47,10 @@ The name must satisfy the following rules:
 - Each segment must start with a letter.
 - All characters must be alphanumeric or an underscore [a-zA-Z0-9_].
   :::
+  
+:::note
+Do not chose an app name containing the string "obytes" or setup script will replace it with "expo-owner"
+:::
 
 ## Open Project on Cursor or VS Code
 


### PR DESCRIPTION
## What does this do?

Add a note to the documentation telling users not to use the string "obytes" in the name of their project

## Why did you do this?
To solves this issue I just opened #485 