### PR TITLE
fix(docs): remove old references to NativeWind

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When creating this starter kit, we had several guiding principles in mind::
 
 - ✅ Latest Expo SDK with Custom Dev Client: Leverage the best of the Expo ecosystem while maintaining full control over your app.
 - 🎉 [TypeScript](https://www.typescriptlang.org/) for enhanced code quality and bug prevention through static type checking.
-- 💅 Minimal UI kit built with [TailwindCSS](https://www.nativewind.dev/), featuring common components essential for your app.
+- 💅 Minimal UI kit built with [TailwindCSS](https://uniwind.dev/), featuring common components essential for your app.
 - ⚙️ Multi-environment build support (Production, Staging, Development) using Expo configuration.
 - 🦊 Husky for Git Hooks: Automate your git hooks and enforce code standards.
 - 💡 Clean project structure with Absolute Imports for easier code navigation and management.
@@ -92,7 +92,7 @@ We value the feedback and contributions of our users, and we encourage you to le
 
 - [Expo](https://docs.expo.io/)
 - [Expo Router](https://docs.expo.dev/router/introduction/)
-- [Nativewind](https://www.nativewind.dev/v4/overview)
+- [Uniwind](https://uniwind.dev/)
 - [Flash list](https://github.com/Shopify/flash-list)
 - [React Query](https://tanstack.com/query/v4)
 - [Axios](https://axios-http.com/docs/intro)

--- a/claude.md
+++ b/claude.md
@@ -5,7 +5,7 @@
 - **Expo SDK 54** with React Native 0.81.5 - Managed React Native development
 - **TypeScript** - Strict type safety throughout
 - **Expo Router 6** - File-based routing (like Next.js)
-- **TailwindCSS** via Uniwind/Nativewind - Utility-first styling for React Native
+- **TailwindCSS** via Uniwind - Utility-first styling for React Native
 - **Zustand** - Lightweight global state management
 - **React Query** - Server state and data fetching
 - **TanStack Form + Zod** - Type-safe form handling and validation
@@ -55,7 +55,7 @@ pnpm build:production:ios       # EAS production build
 - **Forms**: Use TanStack Form + Zod (see `src/features/auth/components/login-form.tsx`)
 - **Data fetching**: Use React Query (see `src/features/feed/api.ts`)
 - **Global state**: Use Zustand (see `src/features/auth/use-auth-store.tsx`)
-- **Styling**: NativeWind/Tailwind classes (see `src/components/ui/button.tsx`)
+- **Styling**: Uniwind/Tailwind classes (see `src/components/ui/button.tsx`)
 - **Storage**: Use MMKV via `src/lib/storage.tsx` for sensitive data
 - **Imports**: Always use `@/` prefix, never relative imports
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,7 +14,6 @@
 
 ```sh
 npx create-obytes-app@latest MyApp
-
 ```
 
 # Overview
@@ -46,7 +45,7 @@ When creating this starter kit, we had several guiding principles in mind::
 
 - ✅ The latest version of Expo SDK, along with the Custom Dev client, to give you access to a range of powerful features and tools.
 - 🎉 [TypeScript](https://www.typescriptlang.org/) for type checking, to help you catch bugs and improve code quality.
-- 💅 A minimal UI kit built with [tailwindcss](https://www.nativewind.dev/), which provides a range of pre-defined classes for styling your app.
+- 💅 A minimal UI kit built with [TailwindCSS](https://uniwind.dev/), which provides a range of pre-defined classes for styling your app.
 - ⚙️ Support for multiple environment builds, including Production, Staging, and Development, using Expo configuration.
 - 🦊 Husky for Git Hooks, to automate your git hooks and enforce code standards.
 - 💡 A clean project structure with Absolute Imports, to make it easier to navigate and manage your code.
@@ -103,7 +102,7 @@ We value the feedback and contributions of our users, and we encourage you to le
 
 - [Expo](https://docs.expo.io/)
 - [Expo Router](https://docs.expo.dev/router/introduction/)
-- [Nativewind](https://www.nativewind.dev/)
+- [Uniwind](https://uniwind.dev/)
 - [Flash list](https://github.com/Shopify/flash-list)
 - [React Query](https://tanstack.com/query/v4)
 - [Axios](https://axios-http.com/docs/intro)
@@ -114,7 +113,7 @@ We value the feedback and contributions of our users, and we encourage you to le
 - [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/)
 - [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/)
 - [React Native Svg](https://github.com/software-mansion/react-native-svg)
-- [ React Error Boundaries](https://github.com/bvaughn/react-error-boundary)
+- [React Error Boundaries](https://github.com/bvaughn/react-error-boundary)
 - [Expo Image](https://docs.expo.dev/versions/unversioned/sdk/image/)
 
 ## Contributors

--- a/nativewind-env.d.ts
+++ b/nativewind-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="nativewind/types" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts",
-    "nativewind-env.d.ts",
+    "uniwind-types.d.ts",
     "env.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## What does this do?

Removed the remaining references to NativeWind, and replaced it with Uniwind.