### PR TITLE
fix: update @env alias in babel.config.js from env.js to env.ts

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,7 @@ module.exports = function (api) {
           root: ['./'],
           alias: {
             '@': './src',
-            '@env': './src/lib/env.js',
+            '@env': './env.ts',
           },
           extensions: [
             '.ios.ts',


### PR DESCRIPTION
The `@env` module alias pointed to `./src/lib/env.js`, which doesn't exist. The env file lives at the project root as `env.ts`.

```diff
// babel.config.js
- '@env': './src/lib/env.js',
+ '@env': './env.ts',
```