### PR TITLE
fix: hide splash screen on onboarding and login screens

### DIFF
--- a/src/features/auth/login-screen.tsx
+++ b/src/features/auth/login-screen.tsx
@@ -1,5 +1,6 @@
 import type { LoginFormProps } from './components/login-form';
 import { useRouter } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
 
 import * as React from 'react';
 import { FocusAwareStatusBar } from '@/components/ui';
@@ -9,6 +10,10 @@ import { useAuthStore } from './use-auth-store';
 export function LoginScreen() {
   const router = useRouter();
   const signIn = useAuthStore.use.signIn();
+
+  React.useEffect(() => {
+    SplashScreen.hideAsync();
+  }, []);
 
   const onSubmit: LoginFormProps['onSubmit'] = (data) => {
     console.log(data);

--- a/src/features/onboarding/onboarding-screen.tsx
+++ b/src/features/onboarding/onboarding-screen.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
 
 import {
@@ -14,6 +15,11 @@ import { Cover } from './components/cover';
 export function OnboardingScreen() {
   const [_, setIsFirstTime] = useIsFirstTime();
   const router = useRouter();
+
+  React.useEffect(() => {
+    SplashScreen.hideAsync();
+  }, []);
+
   return (
     <View className="flex h-full items-center justify-center">
       <FocusAwareStatusBar />

--- a/src/lib/storage.tsx
+++ b/src/lib/storage.tsx
@@ -3,8 +3,16 @@ import { createMMKV } from 'react-native-mmkv';
 export const storage = createMMKV();
 
 export function getItem<T>(key: string): T | null {
-  const value = storage.getString(key);
-  return value ? JSON.parse(value) || null : null;
+  try {
+    const value = storage.getString(key);
+    if (!value)
+      return null;
+    return JSON.parse(value) ?? null;
+  }
+  catch (e) {
+    console.error(`Failed to get item "${key}":`, e);
+    return null;
+  }
 }
 
 export async function setItem<T>(key: string, value: T) {


### PR DESCRIPTION
## What does this do?

Adds `SplashScreen.hideAsync()` calls to `onboarding-screen.tsx` and `login-screen.tsx`, and adds error handling to `storage.getItem()`.

## Why did you do this?

**Bug**: The app was stuck on the splash screen.

**Root cause**: `SplashScreen.hideAsync()` was only called in `TabLayout`'s `useEffect`, but when `isFirstTime` is `true` or user is signed out, the app redirects to `onboarding` or `login` screens before `TabLayout` renders. This means the splash screen hiding logic never executes.

Additionally, `storage.getItem()` could throw on `JSON.parse` errors, potentially blocking auth hydration and leaving `status` as `idle`.

## Who/what does this impact?

- Users on first app launch (onboarding flow)
- Users who are not signed in (login flow)
- Any code path that redirects away from `TabLayout` before splash screen can be hidden

## How did you test this?

1. Cleared app data to simulate first-time user
2. Observed app now correctly shows onboarding screen instead of being stuck on splash
3. Tested login screen after onboarding - splash screen hides correctly
4. Added console logs to verify auth hydration completes with correct status