### PR TITLE
Update README.md to correct link name from Nativewind to Uniwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ We value the feedback and contributions of our users, and we encourage you to le
 
 - [Expo](https://docs.expo.io/)
 - [Expo Router](https://docs.expo.dev/router/introduction/)
-- [Uniwind](https://www.nativewind.dev/v4/overview)
+- [Uniwind](https://uniwind.dev/)
 - [Flash list](https://github.com/Shopify/flash-list)
 - [React Query](https://tanstack.com/query/v4)
 - [Axios](https://axios-http.com/docs/intro)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ We value the feedback and contributions of our users, and we encourage you to le
 
 - [Expo](https://docs.expo.io/)
 - [Expo Router](https://docs.expo.dev/router/introduction/)
-- [Nativewind](https://www.nativewind.dev/v4/overview)
+- [Uniwind](https://www.nativewind.dev/v4/overview)
 - [Flash list](https://github.com/Shopify/flash-list)
 - [React Query](https://tanstack.com/query/v4)
 - [Axios](https://axios-http.com/docs/intro)


### PR DESCRIPTION
## What does this do?

This PR updates the `README.md` file to correct the styling library mentioned in the "Libraries used" section. Specifically, it changes "Nativewind" to "Uniwind" on line 95.

## Why did you do this?

Upon reviewing the `package.json`, the project uses `uniwind` (`^1.2.4`) as a dependency alongside Tailwind CSS v4, and `nativewind` is not actually installed. This change ensures the documentation accurately reflects the current tech stack, preventing any confusion for developers adopting this template.

## Who/what does this impact?

This change only impacts the documentation (`README.md`). It improves clarity for new users and contributors reading about the template's features. There are no downstream code or functional side effects.

## How did you test this?

I cross-referenced the `dependencies` list in `package.json` with the "Libraries used" section in the `README.md` to confirm the discrepancy, and verified the Markdown formatting of the updated line.
